### PR TITLE
Add a package.json for JSON consumption from JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@substrate/ss58-registry",
+  "version": "0.1",
+  "license": "Apache-2",
+  "description": "Registry for SS58 account types",
+  "author": "Parity Technologies <admin@parity.io>",
+  "main": "ss58-registry-derive/src/ss58-registry.json",
+  "repository": "https://github.com/paritytech/ss58-registry",
+  "scripts": {},
+  "devDependencies": {},
+  "dependencies": {}
+}


### PR DESCRIPTION
This allows use to actually consume this (via a git package.json dependency initially), from locations such as https://github.com/polkadot-js/common/tree/master/packages/networks

So this is not the be-all and end-all, i.e.

- we probably want to really publish this (from CI) to the NPM registry
- we probably want to (like I've done in the above repo), convert the JSON to TypeScript/Javascript

However, this is a start. With this at least I can get rid of duplication in the linked repo and start pulling it directly from here.