### PR TITLE
Move ss58-registry.json location for JS consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2",
   "description": "Registry for SS58 account types",
   "author": "Parity Technologies <admin@parity.io>",
-  "main": "ss58-registry-derive/src/ss58-registry.json",
+  "main": "ss58-registry.json",
   "repository": "https://github.com/paritytech/ss58-registry",
   "scripts": {},
   "devDependencies": {},


### PR DESCRIPTION
Needed after https://github.com/paritytech/ss58-registry/pull/8