### PR TITLE
Add CESS network ss58 address prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.0.0"
+version = "1.1.0"
 edition = "2018"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -657,6 +657,15 @@
       "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://ata.network"
-    }
+    },
+		{
+			"prefix": 10042,
+			"network": "CESS",
+			"displayName": "CESS",
+			"symbols": ["TCESS"],
+			"decimals": [12],
+			"standardAccount": "*25519",
+			"website": "https://cess.cloud"
+		}
   ]
 }


### PR DESCRIPTION
This PR adds an address prefix for the CESS network with the prefix 10042.

Website: [cess.cloud](https://cess.cloud)