### PR TITLE
Reserve ss58 prefix 12191 for NFTMart

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -837,6 +837,15 @@
       "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://ata.network"
+    },
+    {
+      "prefix": 12191,
+      "network": "nftmart",
+      "displayName": "NFTMart",
+      "symbols": ["NMT"],
+      "decimals": [12],
+      "standardAccount": "*25519",
+      "website": "https://nftmart.io"
     }
   ]
 }


### PR DESCRIPTION
This PR adds NFTMart to the SS58 registry with prefix 12191. (previously https://github.com/paritytech/substrate/pull/9973)

NFTMart is a Substrate based NFT marketplace. We chose prefix 12191 so all addresses will start with `nm`.

Website: https://nftmart.io

Substrate based node codebase: https://github.com/nftt-studio/nftmart-node

Active network: https://mainnet.nftmart.io/
Explorer: https://scan.nftmart.io/mainnet
Telemetry: https://telemetry.polkadot.io/#list/0xfcf9074303d8f319ad1bf0195b145871977e7c375883b834247cb01ff22f51f9
App: https://app.nftmart.io

Socials:
Twitter: https://twitter.com/nftmartio
Telegram: https://t.me/NFTMartio
Medium: https://nftmart-io.medium.com/
Discord: https://discord.gg/jNMeDvvvvR
GitHub: https://github.com/NFTT-studio

Update in Jan 2022:
App link
Telegram group link