### PR TITLE
add anmol mainnet and testnet address prefixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -560,6 +560,15 @@
       "website": "https://polkadex.trade"
     },
     {
+      "prefix": 92,
+      "network": "anmol",
+      "displayName": "Anmol Network",
+      "symbols": ["ANML"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://anmol.network/"
+    },
+    {
       "prefix": 98,
       "network": "polkasmith",
       "displayName": "PolkaSmith Canary Network",
@@ -576,6 +585,15 @@
       "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://polkafoundry.com"
+    },
+    {
+      "prefix": 100,
+      "network": "ibtida",
+      "displayName": "Anmol Network Ibtida testnet",
+      "symbols": ["tANML"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://anmol.network/"
     },
     {
       "prefix": 101,
@@ -720,7 +738,7 @@
       "decimals": [12],
       "standardAccount": "Sr25519",
       "website": "https://ajuna.io"
-    },    
+    },
     {
       "prefix": 2007,
       "network": "kapex",

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -589,8 +589,8 @@
     {
       "prefix": 100,
       "network": "ibtida",
-      "displayName": "Anmol Network Ibtida testnet",
-      "symbols": ["tANML"],
+      "displayName": "Anmol Network Ibtida Canary network",
+      "symbols": ["IANML"],
       "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://anmol.network/"


### PR DESCRIPTION
The Anmol team wishes to register the 100 prefix for our testnet: ibtida & 92 prefix for our mainnet. This is to easily identify addresses and to prevent re-use across our imminently launching test net and future mainnet.

Please let us know of any feedback and thank you for your time.