### PR TITLE
Publish tag on a new version in Cargo.toml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -171,5 +171,5 @@ unleash-to-crates-io:
         cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS};
         cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF};
       else
-        echo "Tag hasn't changed";
+        echo "Tag was not updated. Not releasing.";
       fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,13 @@ variables:                         &default-vars
   VAULT_AUTH_PATH:                 "gitlab-parity-io-jwt"
   VAULT_AUTH_ROLE:                 "cicd_gitlab_parity_${CI_PROJECT_NAME}"
 
+.publish-refs:                     &publish-refs
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "web"
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
+
 #### Vault secrets
 .vault-secrets:                    &vault-secrets
   secrets:
@@ -122,13 +129,15 @@ build:
 tag-job:
   stage: tag
   <<:                              *kubernetes-env
+  <<:                              *vault-secrets
+  <<:                              *publish-refs
   script:
     - export CURRENT_TAG=$(git describe --tags --abbrev=0)
     - export PKG_VER=v$(cat Cargo.toml | grep -A 5 package] | grep version | cut -d '=' -f 2 | tr -d '"' | tr -d " ")
     - echo $CURRENT_TAG $PKG_VER
-    - git config user.name "$GITHUB_USER"
+    - git config user.name "${GITHUB_USER}"
     - git config user.email "devops-team@parity.io"
-    - git config remote.origin.url "https://$GITHUB_TOKEN@github.com/paritytech/${CI_PROJECT_NAME}.git"
+    - git config remote.origin.url "https://${GITHUB_TOKEN}@github.com/paritytech/${CI_PROJECT_NAME}.git"
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - if [ $CURRENT_TAG == $PKG_VER  ];
         then
@@ -152,6 +161,7 @@ unleash-to-crates-io:
   stage:                           publish
   <<:                              *kubernetes-env
   <<:                              *vault-secrets
+  <<:                              *publish-refs
   script:
     - echo $TAG
     - if [ $TAG == "new"  ];

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -145,7 +145,7 @@ tag-job:
           echo "Tag is up to date. Nothing to do.";
           export TAG=old;
         else
-          echo "Tag has changed";
+          echo "Tag was updated.";
           git tag -a $PKG_VER -m "new tag";
           git tag --list;
           git push origin --tags;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -147,7 +147,7 @@ tag-job:
         else
           echo "Tag was updated.";
           git tag -a $PKG_VER -m "new tag";
-          git tag --list;
+          git log --tags --simplify-by-decoration --pretty="format:%ci %d";
           git push origin --tags;
           export TAG=new;
         fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@ stages:
   - lint
   - test
   - build
+  - tag
   - publish
 
 variables:                         &default-vars
@@ -21,6 +22,12 @@ variables:                         &default-vars
   secrets:
     CRATES_TOKEN:
       vault:                       cicd/gitlab/$CI_PROJECT_PATH/CRATES_TOKEN@kv
+      file:                        false
+    GITHUB_TOKEN:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITHUB_TOKEN@kv
+      file:                        false
+    GITHUB_USER:
+      vault:                       cicd/gitlab/$CI_PROJECT_PATH/GITHUB_USER@kv
       file:                        false
 
 .rust-info-script:                 &rust-info-script
@@ -108,16 +115,50 @@ build:
   script:
     - cargo build --no-default-features --target wasm32-unknown-unknown --verbose
 
+
+#### stage:                        tag
+# this stage will only create a tag in the repo, not release
+
+tag-job:
+  stage: tag
+  <<:                              *kubernetes-env
+  script:
+    - export CURRENT_TAG=$(git describe --tags --abbrev=0)
+    - export PKG_VER=v$(cat Cargo.toml | grep -A 5 package] | grep version | cut -d '=' -f 2 | tr -d '"' | tr -d " ")
+    - echo $CURRENT_TAG $PKG_VER
+    - git config user.name "$GITHUB_USER"
+    - git config user.email "devops-team@parity.io"
+    - git config remote.origin.url "https://$GITHUB_TOKEN@github.com/paritytech/${CI_PROJECT_NAME}.git"
+    - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+    - if [ $CURRENT_TAG == $PKG_VER  ];
+        then
+          echo "Tag is the same. Nothing to do";
+          export TAG=old;
+        else
+          echo "Tag has changed";
+          git tag -a $PKG_VER -m "new tag";
+          git tag --list;
+          git push origin --tags;
+          export TAG=new;
+        fi
+    - echo "TAG=$TAG" > tag.env;
+  artifacts:
+    reports:
+      dotenv: tag.env
+
 #### stage:                       publish
 
 unleash-to-crates-io:
   stage:                           publish
-  <<:                              *docker-env
+  <<:                              *kubernetes-env
   <<:                              *vault-secrets
-  rules:
-    - if: $CI_COMMIT_REF_NAME =~ /^ci-release-.*$/
-    - if: $CI_COMMIT_REF_NAME =~ /^v[0-9]+\.[0-9]+.*$/              # i.e. v1.0, v2.1rc1
   script:
-    - cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS}
-    - cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF}
-
+    - echo $TAG
+    - if [ $TAG == "new"  ];
+      then
+        echo "Publishing to crates.io";
+        cargo install cargo-unleash ${CARGO_UNLEASH_INSTALL_PARAMS};
+        cargo unleash em-dragons --no-check --owner github:paritytech:core-devs ${CARGO_UNLEASH_PKG_DEF};
+      else
+        echo "Tag hasn't changed";
+      fi

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -160,7 +160,7 @@ tag-job:
 
 unleash-to-crates-io:
   stage:                           publish
-  <<:                              *kubernetes-env
+  <<:                              *docker-env
   <<:                              *vault-secrets
   <<:                              *publish-refs
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -134,7 +134,8 @@ tag-job:
   script:
     - export CURRENT_TAG=$(git describe --tags --abbrev=0)
     - export PKG_VER=v$(cat Cargo.toml | grep -A 5 package] | grep version | cut -d '=' -f 2 | tr -d '"' | tr -d " ")
-    - echo $CURRENT_TAG $PKG_VER
+    - echo "Current tag $CURRENT_TAG"
+    - echo "Package version $PKG_VER"
     - git config user.name "${GITHUB_USER}"
     - git config user.email "devops-team@parity.io"
     - git config remote.origin.url "https://${GITHUB_TOKEN}@github.com/paritytech/${CI_PROJECT_NAME}.git"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,7 @@ tag-job:
     - git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
     - if [ $CURRENT_TAG == $PKG_VER  ];
         then
-          echo "Tag is the same. Nothing to do";
+          echo "Tag is up to date. Nothing to do.";
           export TAG=old;
         else
           echo "Tag has changed";


### PR DESCRIPTION
Add additional `tag` step to the pipeline and changed `cargo-unleash`. 

The `tag` step checks version in `Cargo.toml` file and compares it with the current tag. If it differs, then the new tag is pushed to github repo. This step doesn't create a release, only publishes the tag. Also it creates env variable for `cargo_uhleash`.

`cargo_unleash` now runs on every push to master, but publishing to crates.io happens only if tag was changed on the previous `tag` step

Closes https://github.com/paritytech/ss58-registry/issues/28
Closes https://github.com/paritytech/ci_cd/issues/243