### PR TITLE
We should make it clear that the crate is no_std if not std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#![cfg_attr(not(feature = "std"),no_std)]
 #![warn(missing_docs)]
 
 //! List of well-known SS58 account types as an enum.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![cfg_attr(not(feature = "std"),no_std)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
 
 //! List of well-known SS58 account types as an enum.


### PR DESCRIPTION
We should make it clear that this crate is no_std compatible.