### PR TITLE
bump crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2018"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"


### PR DESCRIPTION
release the change to make explicitly no_std.