### PR TITLE
Update decimal and token symbol for Manta Network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.8.1"
+version = "1.9.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -527,8 +527,8 @@
       "prefix": 77,
       "network": "manta",
       "displayName": "Manta network",
-      "symbols": ["MA"],
-      "decimals": [12],
+      "symbols": ["MANTA"],
+      "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://manta.network"
     },


### PR DESCRIPTION
Our team(Manta Network) has changed the decimal and token symbol, so we have to update it for ss58-registry.