### PR TITLE
Add DENTNet prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.20.0"
+version = "1.21.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -848,6 +848,15 @@
       "website": "https://unique.network"
     },
     {
+      "prefix": 9807,
+      "network": "dentnet",
+      "displayName": "DENTNet",
+      "symbols": ["DENTX"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://www.dentnet.io"
+    },
+    {
       "prefix": 10041,
       "network": "basilisk",
       "displayName": "Basilisk",


### PR DESCRIPTION
This PR adds ss58 prefix 9807 for [DENTNet](https://www.dentnet.io), the new mainnet based on Substrate for the global mobile operator DENT. More information can be found on the [roadmap](https://www.dentwireless.com/roadmap).


