### PR TITLE
Add ss58 registry for OAK Network, and its canary network Turing Network.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.10.0"
+version = "1.11.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.13.0"
+version = "1.14.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -470,6 +470,15 @@
       "website": "https://composable.finance"
     },
     {
+      "prefix": 51,
+      "network": "oak",
+      "displayName": "OAK Network",
+      "symbols": ["OAK"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://oak.tech"
+    },
+    {
       "prefix": 55,
       "network": "xxnetwork",
       "displayName": "xx network",

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -254,6 +254,15 @@
       "website": "https://jupiter.patract.io"
     },
     {
+      "prefix": 27,
+      "network": "neumann",
+      "displayName": "Neumann Network",
+      "symbols": ["NEU"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://oak.tech/neumann"
+    },
+    {
       "prefix": 28,
       "network": "subsocial",
       "displayName": "Subsocial",


### PR DESCRIPTION
This is for OAK Network's parachains.

main network: OAK
canary network: Turing

You can find more information here: https://docs.oak.tech/docs/overview/