### PR TITLE
Add types key to package.json exports

### DIFF
--- a/scripts/js/build_js.mjs
+++ b/scripts/js/build_js.mjs
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 const OUTPUT = 'npm_dist/';
-const HEADER = `// Copyright (C) 2021-2022 Parity Technologies (UK) Ltd.
+const HEADER = `// Copyright (C) 2021-${new Date().getFullYear()} Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/scripts/js/build_js.mjs
+++ b/scripts/js/build_js.mjs
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 
 const OUTPUT = 'npm_dist/';
-const HEADER = `// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+const HEADER = `// Copyright (C) 2021-2022 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -32,28 +32,42 @@ function writeWithHeader (file, contents) {
 	writeFile(file, `${HEADER}\n${contents}`);
 }
 
+function adjustPkg (pkgJson, obj) {
+	Object.entries(obj).forEach(([k, v]) => {
+		delete pkgJson[k];
+
+		if (v !== undefined) {
+			pkgJson[k] = v;
+		}
+	});
+}
+
 function main () {
 	const typesD = fs.readFileSync('types.d.ts', 'utf-8');
 	const pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 	const { registry } = JSON.parse(fs.readFileSync('ss58-registry.json', 'utf-8'));
 
 	// mangle the code output into something JS-like
-	const code = JSON.stringify(registry, null, 2)
-		.replace(/\n    "/g, '\n\t\t') // change the leading key " into '
+	const code = JSON.stringify(registry, null, '\t')
+		.replace(/\n\t\t"/g, '\n\t\t') // change the leading key " into '
 		.replace(/":/g, ':') // change the trailing key ": into :
-		.replace(/"/g, "'") // use single quotes elsewhere
-		.replace(/  /g, '\t'); // change all spaces into tabs
+		.replace(/"/g, "'") ;// use single quotes elsewhere
 
-	pkgJson.exports = {
-		'.': {
-			require: './index.cjs',
-			default: './index.js'
+	adjustPkg(pkgJson, {
+		exports: {
+			'.': {
+				types: './index.d.ts',
+				require: './index.cjs',
+				default: './index.js'
+			}
 		},
-	};
-	pkgJson.main = 'index.js';
-	pkgJson.type = 'module';
-
-	delete pkgJson.scripts;
+		main: 'index.cjs',
+		module: 'index.js',
+		types: 'index.d.ts',
+		type: 'module',
+		scripts: undefined,
+		devDependencies: undefined
+	});
 
 	writeWithHeader('index.cjs', `module.exports = ${code};\n`);
 	writeWithHeader('index.js', `export default ${code};\n`);

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2021 Parity Technologies (UK) Ltd.
+// Copyright (C) 2021-2022 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Small cleanups to the JS generated output script -

- Use `\t` in JSON.stringify (removing the replacement of spaces)
- Add the `types` key to the exports map (added first as per TS recommendation)
- Add the `module` field to `package.json` pointing to `index.js`
- Correct the `main` field in `package.json` to point to `index.cjs` (Now that we have the `module` field)
- DRY-er build steps for the generation of `package.json`
- Adjust output JS headers to include current build year (As per suggestion in PR)

Sample of the now-generated package.json from master -

```json
{
  "name": "@substrate/ss58-registry",
  "version": "1.2.0",
  "license": "Apache-2",
  "description": "Registry for SS58 account types",
  "author": "Parity Technologies <admin@parity.io>",
  "repository": "https://github.com/paritytech/ss58-registry",
  "dependencies": {},
  "exports": {
    ".": {
      "types": "./index.d.ts",
      "require": "./index.cjs",
      "default": "./index.js"
    }
  },
  "main": "index.cjs",
  "module": "index.js",
  "types": "index.d.ts",
  "type": "module"
}
```