### PR TITLE
Add Litmus networks to the registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.11.0"
+version = "1.12.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -623,6 +623,15 @@
       "website": "https://clover.finance"
     },
     {
+      "prefix": 131,
+      "network": "litmus",
+      "displayName": "Litmus Network",
+      "symbols": ["LIT"],
+      "decimals": [12],
+      "standardAccount": "*25519",
+      "website": "https://litentry.com/"
+    },
+    {
       "prefix": 136,
       "network": "altair",
       "displayName": "Altair",


### PR DESCRIPTION
Hi, we'd like to add `Litmus network` which is the kusama-parachain from Litentry.

The token metadata is the same the `Litentry network` as we are not planning to issue new tokens on kusama parachain.