### PR TITLE
Small JS package build cleanups

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/ss58-registry",
-  "version": "1.2.0",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@substrate/ss58-registry",
-  "version": "1.2.0",
-  "license": "Apache-2",
+  "version": "1.12.0",
+  "license": "Apache-2.0",
   "description": "Registry for SS58 account types",
   "author": "Parity Technologies <admin@parity.io>",
   "main": "ss58-registry.json",
   "repository": "https://github.com/paritytech/ss58-registry",
   "scripts": {
     "alignVersion": "./scripts/js/align_version.mjs && npm install",
-    "build": "rm -rf npm_dist && mkdir -p npm_dist && ./scripts/js/build_js.mjs"
+    "build": "npm run alignVersion && rm -rf npm_dist && mkdir -p npm_dist && ./scripts/js/build_js.mjs"
   },
   "devDependencies": {
     "toml": "^3.0.0"

--- a/scripts/js/build_js.mjs
+++ b/scripts/js/build_js.mjs
@@ -20,8 +20,10 @@ const HEADER = `// Copyright (C) 2021-${new Date().getFullYear()} Parity Technol
 // limitations under the License.
 `;
 
-function copyFile (file) {
-	writeFile(file, fs.readFileSync(file, 'utf-8'));
+function copyFiles (...files) {
+	files.forEach((f) =>
+		writeFile(f, fs.readFileSync(f, 'utf-8'))
+	);
 }
 
 function writeFile (file, contents) {
@@ -45,13 +47,8 @@ function adjustPkg (pkgJson, obj) {
 function main () {
 	const typesD = fs.readFileSync('types.d.ts', 'utf-8');
 	const pkgJson = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-	const { registry } = JSON.parse(fs.readFileSync('ss58-registry.json', 'utf-8'));
-
-	// mangle the code output into something JS-like
-	const code = JSON.stringify(registry, null, '\t')
-		.replace(/\n\t\t"/g, '\n\t\t') // change the leading key " into '
-		.replace(/":/g, ':') // change the trailing key ": into :
-		.replace(/"/g, "'") ;// use single quotes elsewhere
+	const all = JSON.parse(fs.readFileSync('ss58-registry.json', 'utf-8'));
+	const code = JSON.stringify(all.registry, null, '\t');
 
 	adjustPkg(pkgJson, {
 		exports: {
@@ -59,7 +56,8 @@ function main () {
 				types: './index.d.ts',
 				require: './index.cjs',
 				default: './index.js'
-			}
+			},
+			'./package.json': './package.json'
 		},
 		main: 'index.cjs',
 		module: 'index.js',
@@ -75,9 +73,7 @@ function main () {
 	writeFile('package.json', JSON.stringify(pkgJson, null, 2));
 	writeFile('index.d.ts', `${typesD}\ndeclare const _default: Registry;\n\nexport default _default;\n`);
 
-	copyFile('CHANGELOG.md');
-	copyFile('README.md');
-	copyFile('LICENSE');
+	copyFiles('CHANGELOG.md', 'README.md', 'LICENSE');
 }
 
 main();


### PR DESCRIPTION
Nothing critical contained within, but does apply a number of cleanups -

1. Expose the `package.json` inside the `exports` map - Reach Native reads this with node resolution, which means some older versions would have issues without the field explicitly specified.
2. Change `copyFile` into `copyFiles` allowing us to call only once and then loop.
3. Run the `alignVersion` script as part of the build (this makes the npm publish less fiddly, i.re only one command is to be called instead of 2 - cc @alvicsam)
4. Adjust the `license` key in `package.json` with a valid SPDX identifier (non critical, but silences and npm warning on local install)
5. Get rid of the JS output `s/"/'/g` mangling, as-is it is valid JS anyway, so this is fragile and adds no immediate value