### PR TITLE
[ci] modify publish-npmjs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -192,7 +192,6 @@ publish-npmjs:
       then
         echo "------------Publishing to npmjs------------";
         npm install;
-        npm run alignVersion;
         npm run build;
         cd npm_dist/;
         echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc;


### PR DESCRIPTION
According to https://github.com/paritytech/ss58-registry/pull/72 the `npm run alignVersion` command from `publish-npmjs` can be removed. It is now part of `npm run build`