### PR TITLE
Kabocha, KAB, prefix 27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.12.0"
+version = "1.13.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -254,6 +254,15 @@
       "website": "https://jupiter.patract.io"
     },
     {
+      "prefix": 27,
+      "network": "kabocha",
+      "displayName": "Kabocha",
+      "symbols": ["KAB"],
+      "decimals": [12],
+      "standardAccount": "*25519",
+      "website": "https://kabocha.network"
+    },
+    {
       "prefix": 28,
       "network": "subsocial",
       "displayName": "Subsocial",


### PR DESCRIPTION
Registering prefix 27 for Kabocha parachain candidate for Kusama (https://kabocha.network)
