### PR TITLE
Build JS ESM/CJS to subdirs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,24 @@
 {
   "name": "@substrate/ss58-registry",
-  "version": "1.12.0",
-  "lockfileVersion": 1,
+  "version": "1.17.0",
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "@substrate/ss58-registry",
+      "version": "1.17.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "toml": "^3.0.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "dev": true
+    }
+  },
   "dependencies": {
     "toml": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@substrate/ss58-registry",
-  "version": "1.12.0",
+  "version": "1.17.0",
   "license": "Apache-2.0",
   "description": "Registry for SS58 account types",
   "author": "Parity Technologies <admin@parity.io>",


### PR DESCRIPTION
This changes the JS build step slightly to just place the outputs into `{esm, cjs}/index.js`. From a consumption point of view this has no adverse impacts since the `main/module` and `export` point to the new locations. 

The benefit here is for users who are using older bundlers (there are a lot of them around... still) who are consuming the older CJS version. The `.cjs` extension is still "relatively" new and not configured-out-of-the-box on previous-generation bundlers, React Native and older versions of create-react-app being examples. The lack of a `.cjs` extension in the output  here makes it easier for them to pull in without any additional bundler configuration.

For users of current-generation bundlers, there is no impact due to the `export` maps.