### PR TITLE
Rocfinity: Efinity's rococo deployment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.17.0"
+version = "1.18.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -722,6 +722,15 @@
       "website": "https://efinity.io/"
     },
     {
+      "prefix": 195,
+      "network": "rocfinity",
+      "displayName": "Rocfinity",
+      "symbols": ["RFI"],
+      "decimals": [18],
+      "standardAccount": "Sr25519",
+      "website": "https://efinity.io/"
+    },
+    {
       "prefix": 1284,
       "network": "moonbeam",
       "displayName": "Moonbeam",


### PR DESCRIPTION
Cargo.toml: Bumped minor version
ss58-registry.json: Added the generated prefix we started using for that network.