### PR TITLE
Add GM parachain with prefix 7013

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.20.0"
+version = "1.21.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -839,6 +839,15 @@
       "website": "https://tidefi.com"
     },
     {
+      "prefix": 7013,
+      "network": "gm",
+      "displayName": "GM",
+      "symbols": ["FREN", "GM", "GN"],
+      "decimals": [12, 0, 0],
+      "standardAccount": "*25519",
+      "website": "https://gmordie.com"
+    },
+    {
       "prefix": 7391,
       "network": "unique_mainnet",
       "displayName": "Unique Network",


### PR DESCRIPTION
In the near future the GM chain will go for a Kusama slot, this PR is for requesting the prefix 7013 to be used with GM parachain account addresses. There is no hurry to merge this.