### PR TITLE
Correct nodle's decimals

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -330,7 +330,7 @@
       "network": "nodle",
       "displayName": "Nodle Chain",
       "symbols": ["NODL"],
-      "decimals": [18],
+      "decimals": [11],
       "standardAccount": "*25519",
       "website": "https://nodle.io/"
     },


### PR DESCRIPTION
Correct the decimals to match what the system.properties rpc returns for [Nodle parachain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fnodle-parachain.api.onfinality.io%2Fpublic-ws#/rpc). Nodle has been using 11 decimals sine November 15th 2021 and even before that it was 12 and not 18.