### PR TITLE
chore(ss58-registry.json): update TIDEFI-token symbol

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -878,7 +878,7 @@
       "prefix": 7007,
       "network": "tidefi",
       "displayName": "Tidefi",
-      "symbols": ["TIFI"],
+      "symbols": ["TDFY"],
       "decimals": [12],
       "standardAccount": "*25519",
       "website": "https://tidefi.com"


### PR DESCRIPTION
Our token symbol has changed from TIFI -> TDFY. This PR is aimed at correcting that. 

Thank you.