### PR TITLE
Add eggnet prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.23.0"
+version = "1.24.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -866,6 +866,15 @@
       "website": "https://subspace.network"
     },
     {
+      "prefix": 4006,
+      "network": "Eggnet",
+      "displayName": "Egg Network",
+      "symbols": ["EGG"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://www.webb.tools/"
+    },
+    {
       "prefix": 6094,
       "network": "subspace",
       "displayName": "Subspace",


### PR DESCRIPTION
Add egg-net prefix to registry

```
{
      "prefix": 4006,
      "network": "Eggnet",
      "displayName": "Egg Network",
      "symbols": ["EGG"],
      "decimals": [18],
      "standardAccount": "*25519",
      "website": "https://www.webb.tools/"
 }
```