### PR TITLE
Adding prefix 2114 - Turing Network

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -1017,6 +1017,15 @@
       "decimals": [12],
       "standardAccount": "*25519",
       "website": "https://nftmart.io"
-    }
+    },
+    {
+      "prefix": 2114,
+      "network": "turing",
+      "displayName": "Turing Network",
+      "symbols": ["TUR"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://oak.tech/turing/home/"
+    } 
   ]
 }


### PR DESCRIPTION
Adding Turing Network, the canary network of OAK (prefix 51).

OAK Network is web3’s hub for cross-chain automation, enabling multi-chain apps to automate any substrate extrinsic or EVM smart contract function. OAK is built for cross-chain automation, dedicating its block space and optimizing gas to store, trigger, and execute transactions on connected blockchains.