### PR TITLE
Update to include 2114: Turing Network

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -893,6 +893,15 @@
       "website": "https://chainflip.io/"
     },
     {
+      "prefix": 2114,
+      "network": "Turing",
+      "displayName": "Turing Network",
+      "symbols": ["TUR"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://oak.tech/turing/home/"
+    },
+    {
       "prefix": 2207,
       "network": "SNOW",
       "displayName": "SNOW: ICE Canary Network",


### PR DESCRIPTION
Turing Network is the canary network for OAK, the web3 hub for trustless automation. OAK enables multi-chain dapps to automate any blockchain transaction using simple "if this" trigger condition and "then that" transaction instruction.