### PR TITLE
upgrade num-format to 0.4.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default = ["std"]
 std = ["num-format"]
 
 [dependencies]
-num-format = { version = "0.4.0", optional = true }
+num-format = { version = "0.4.3", optional = true }
 
 [build-dependencies]
 quote = { version = "1.0.15", default-features = false }


### PR DESCRIPTION
I'm the author of `num-format`, one of your dependencies. Unfortunately I went a long time without maintaining the crate. But today I updated it. The public API hasn't changed, but I upgraded a number of `num-format`'s old dependencies, notably...

* arrayvec 0.4 -> 0.7.2
* itoa 0.4 -> 1.0.4

This PR updates your version of `num-format` to the latest release (0.4.3)