### PR TITLE
Add t0rn Testnet to the registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.31.0"
+version = "1.32.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -1100,6 +1100,15 @@
       "website": "https://www.dentnet.io"
     },
     {
+      "prefix": 9935,
+      "network": "t0rn",
+      "displayName": "t0rn Testnet",
+      "symbols": ["T0RN"],
+      "decimals": [12],
+      "standardAccount": "*25519",
+      "website": "https://t3rn.io/"
+    },
+    {
       "prefix": 10041,
       "network": "basilisk",
       "displayName": "Basilisk",


### PR DESCRIPTION
```
{
      "prefix": 9935,
      "network": "t0rn",
      "displayName": "t0rn Testnet",
      "symbols": ["T0RN"],
      "decimals": [12],
      "standardAccount": "*25519",
      "website": "https://t3rn.io/"
    },
```