### PR TITLE
Add DeFiChain EVM Network registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.38.0"
+version = "1.39.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -875,6 +875,15 @@
       "website": "https://efinity.io/"
     },
     {
+      "prefix": 1130,
+      "network": "defichain-evm",
+      "displayName": "DeFiChain EVM Network",
+      "symbols": ["DFI"],
+      "decimals": [18],
+      "standardAccount": "secp256k1",
+      "website": "https://meta.defichain.com"
+    },
+    {
       "prefix": 1221,
       "network": "peaq",
       "displayName": "Peaq Network",
@@ -1017,7 +1026,7 @@
       "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://subspace.network"
-    },    
+    },
     {
       "prefix": 4006,
       "network": "tangle",


### PR DESCRIPTION
As per title. Adds the mainnet and testnet registries for DeFIChain EVM Network.

This is following up from #145 , had to resolve some conflicts.