### PR TITLE
Add dracones main- and test-nets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.39.0"
+version = "1.40.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -1064,6 +1064,15 @@
       "website": "https://subspace.network"
     },
     {
+      "prefix": 6942,
+      "network": "dracones-dwarf",
+      "displayName": "Dracones Testnet",
+      "symbols": ["DUCK"],
+      "decimals": [18],
+      "standardAccount": "secp256k1",
+      "website": "https://wolfery.com"
+    },
+    {
       "prefix": 7007,
       "network": "tidefi",
       "displayName": "Tidefi",
@@ -1089,6 +1098,15 @@
       "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://unique.network"
+    },
+    {
+      "prefix": 8387,
+      "network": "dracones",
+      "displayName": "Dracones Financial Services",
+      "symbols": ["FUCK"],
+      "decimals": [18],
+      "standardAccount": "secp256k1",
+      "website": "https://wolfery.com"
     },
     {
       "prefix": 8883,


### PR DESCRIPTION
Add the dracones networks.

The source code for those is https://github.com/farcaller/dracones-blockchain, a H160-based substrate chain with EVM that's not a moon* fork-off. It's primarily focused on the educational use, featuring a consensus alternative based on raft. It's known as chain 8387 on [the chainlist](https://chainlist.org/chain/8387) so I want to use the same prefix for ss58.

NB: It's not fully clear to me if I _have to_ have an entry in the registry given the address keys don't use ss58 format. But the moon* networks are here so I figured I'd add this one too, just in case something changes for the chain in the future.