### PR TITLE
Correct Composable Finance dispalyName

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -454,7 +454,7 @@
     {
       "prefix": 50,
       "network": "composable",
-      "displayName": "Composable",
+      "displayName": "Composable Finance",
       "symbols": ["LAYR"],
       "decimals": [12],
       "standardAccount": "*25519",


### PR DESCRIPTION
We had an issue adding "Composable Finance" to our app as it was not found in the registry. Fortunately, we resolved it by correcting the display name from "Composable" to "Composable Finance," matching the reference in polkadot.js/apps.