### PR TITLE
Adding network "turing" to ss58-registry.json for Turing Network

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.40.0"
+version = "1.41.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -467,7 +467,7 @@
       "symbols": ["TUR"],
       "decimals": [10],
       "standardAccount": "*25519",
-      "website": "https://oak.tech/turing/token/"
+      "website": "https://oak.tech/turing/token"
     },
     {
       "prefix": 51,

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -462,10 +462,19 @@
     },
     {
       "prefix": 51,
+      "network": "turing",
+      "displayName": "Turing Network",
+      "symbols": ["TUR"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://oak.tech/turing/token/"
+    },
+    {
+      "prefix": 51,
       "network": "oak",
       "displayName": "OAK Network",
-      "symbols": ["OAK", "TUR"],
-      "decimals": [10, 10],
+      "symbols": ["OAK"],
+      "decimals": [10],
       "standardAccount": "*25519",
       "website": "https://oak.tech"
     },


### PR DESCRIPTION
We are trying to add a network id "turing" to the subkey command-line tool for account utility, according to feedback from community developers. In addition, the existing way of defining token symbols in the array of ["OAK","TUR"] is not accurate, as the native tokens are from separate networks, a Kusama parachain and a Polkadot parachain.

Thanks! @DanielCake-Baly my Element is @kezjo:matrix.org. Let me know if you need more information. 