### PR TITLE
Add goro Networks ss58 prefixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.41.0"
+version = "1.42.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -1118,6 +1118,15 @@
       "website": "https://gmordie.com"
     },
     {
+      "prefix": 7306,
+      "network": "krigan",
+      "displayName": "Krigan Network",
+      "symbols": ["KRGN"],
+      "decimals": [9],
+      "standardAccount": "*25519",
+      "website": "https://krigan.network"
+    },
+    {
       "prefix": 7391,
       "network": "unique_mainnet",
       "displayName": "Unique Network",
@@ -1251,6 +1260,15 @@
       "decimals": [9],
       "standardAccount": "*25519",
       "website": "https://bittensor.com"
+    },
+    {
+      "prefix": 14697,
+      "network": "goro",
+      "displayName": "GORO Network",
+      "symbols": ["GORO"],
+      "decimals": [9],
+      "standardAccount": "*25519",
+      "website": "https://goro.network"
     }
   ]
 }


### PR DESCRIPTION
This change consists of 2 prefixes:
- `GORO` Network => `14697`
- Krigan Network (`GORO`'s experimental chain but not its testnet) => `7306`

Please review @DanielCake-Baly 🙏🏽 