### PR TITLE
Adding gitspiegel-trigger workflow

### DIFF
--- a/.github/workflows/gitspiegel-trigger.yml
+++ b/.github/workflows/gitspiegel-trigger.yml
@@ -1,0 +1,20 @@
+name: gitspiegel sync
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - unlocked
+      - ready_for_review
+      - reopened
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sync via API
+        run: |
+          curl --fail-with-body -XPOST "https://gitspiegel.parity-prod.parity.io/api/v1/mirror/${{ github.repository }}/pull/${{ github.event.number }}" \
+           -H "Content-Type: application/json" \
+           -H "x-auth: ${{ secrets.GITSPIEGEL_TOKEN }}"


### PR DESCRIPTION
Using a workflow to trigger mirroring instead of a webhook allows us to reuse "Approving workflow runs from public forks" GitHub feature to somewhat protect us from malicious PRs