### PR TITLE
Update Polimec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.43.0"
+version = "1.44.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -381,12 +381,12 @@
     },
     {
       "prefix": 41,
-      "network": "poli",
-      "displayName": "Polimec Chain",
-      "symbols": [],
-      "decimals": [],
+      "network": "polimec",
+      "displayName": "Polimec Protocol",
+      "symbols": ["PLMC"],
+      "decimals": [10],
       "standardAccount": "*25519",
-      "website": "https://polimec.io/"
+      "website": "https://www.polimec.org/"
     },
     {
       "prefix": 42,


### PR DESCRIPTION
- Update the URL for Polimec's homepage from the old (and unreachable) https://polimec.io/ to the new address: https://www.polimec.org/.
- Add the respective `symbols` and `decimals `