### PR TITLE
Register Entropy BITS

### DIFF
--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -956,6 +956,15 @@
       "website": "https://moonbeam.network"
     },
     {
+      "prefix": 1312,
+      "network": "entropy",
+      "displayName": "Entropy",
+      "symbols": ["BITS"],
+      "decimals": [10],
+      "standardAccount": "*25519",
+      "website": "https://entropy.xyz"
+    },
+    {
       "prefix": 1328,
       "network": "ajuna",
       "displayName": "Ajuna Network",


### PR DESCRIPTION
This PR adds the Entropy token `BITS` to the registry (https://entropy.xyz).

Thank you!