### PR TITLE
feat: Register ESX Network — 9 chain prefixes (11096–13144)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.51.0"
+version = "1.52.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -1244,6 +1244,15 @@
       "website": "https://bsx.fi"
     },
     {
+      "prefix": 11096,
+      "network": "esx-global-identity",
+      "displayName": "ESX Global Identity Chain",
+      "symbols": ["ESXID"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
+    },
+    {
       "prefix": 11330,
       "network": "cess-testnet",
       "displayName": "CESS Testnet",
@@ -1262,6 +1271,15 @@
       "website": "https://cess.cloud"
     },
     {
+      "prefix": 11352,
+      "network": "esx-oceania",
+      "displayName": "ESX Oceania",
+      "symbols": ["ESXOC"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
+    },
+    {
       "prefix": 11486,
       "network": "luhn",
       "displayName": "Luhn Network",
@@ -1271,6 +1289,15 @@
       "website": "https://luhn.network"
     },
     {
+      "prefix": 11608,
+      "network": "esx-middle-east",
+      "displayName": "ESX Middle East",
+      "symbols": ["ESXME"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
+    },
+    {
       "prefix": 11820,
       "network": "contextfree",
       "displayName": "Automata ContextFree",
@@ -1278,6 +1305,24 @@
       "decimals": [18],
       "standardAccount": "*25519",
       "website": "https://ata.network"
+    },
+    {
+      "prefix": 11864,
+      "network": "esx-asia",
+      "displayName": "ESX Asia",
+      "symbols": ["ESXAS"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
+    },
+    {
+      "prefix": 12120,
+      "network": "esx-africa",
+      "displayName": "ESX Africa",
+      "symbols": ["ESXAF"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
     },
     {
       "prefix": 12155,
@@ -1298,6 +1343,24 @@
       "website": "https://nftmart.io"
     },
     {
+      "prefix": 12376,
+      "network": "esx-europe",
+      "displayName": "ESX Europe",
+      "symbols": ["ESXEU"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
+    },
+    {
+      "prefix": 12632,
+      "network": "esx-south-america",
+      "displayName": "ESX South America",
+      "symbols": ["ESXSA"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
+    },
+    {
       "prefix": 12850,
       "network": "analog-timechain",
       "displayName": "Analog Timechain",
@@ -1307,6 +1370,15 @@
       "website": "https://analog.one"
     },
     {
+      "prefix": 12888,
+      "network": "esx-north-america",
+      "displayName": "ESX North America",
+      "symbols": ["ESXNA"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
+    },
+    {
       "prefix": 13116,
       "network": "bittensor",
       "displayName": "Bittensor",
@@ -1314,6 +1386,15 @@
       "decimals": [9],
       "standardAccount": "*25519",
       "website": "https://bittensor.com"
+    },
+    {
+      "prefix": 13144,
+      "network": "esx-global-unity",
+      "displayName": "ESX Global Unity Chain",
+      "symbols": ["ESX"],
+      "decimals": [18],
+      "standardAccount": "*25519",
+      "website": "https://esx.network"
     },
     {
       "prefix": 14697,

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -1246,7 +1246,7 @@
     {
       "prefix": 11096,
       "network": "esx-global-identity",
-      "displayName": "ESX Global Identity Chain",
+      "displayName": "ESX Global Identity",
       "symbols": ["ESXID"],
       "decimals": [18],
       "standardAccount": "*25519",
@@ -1390,7 +1390,7 @@
     {
       "prefix": 13144,
       "network": "esx-global-unity",
-      "displayName": "ESX Global Unity Chain",
+      "displayName": "ESX Global Unity",
       "symbols": ["ESX"],
       "decimals": [18],
       "standardAccount": "*25519",


### PR DESCRIPTION
## Summary

This PR registers 9 SS58 address prefixes for the ESX Network (https://esx.network), an RWA-focused blockchain ecosystem built on Substrate with NPoS consensus (BABE + GRANDPA) and full EVM compatibility via Frontier.

## Chains

| Prefix | Network ID | Display Name | Token | Decimals |
|--------|-----------|--------------|-------|----------|
| 11096 | `esx-identity` | ESX Global Identity | ESXID | 18 |
| 11352 | `esx-oceania` | ESX Oceania | ESXOC | 18 |
| 11608 | `esx-middle-east` | ESX Middle East | ESXME | 18 |
| 11864 | `esx-asia` | ESX Asia | ESXAS | 18 |
| 12120 | `esx-africa` | ESX Africa | ESXAF | 18 |
| 12376 | `esx-europe` | ESX Europe | ESXEU | 18 |
| 12632 | `esx-south-america` | ESX South America | ESXSA | 18 |
| 12888 | `esx-north-america` | ESX North America | ESXNA | 18 |
| 13144 | `esx-unity` | ESX Global Unity | ESX | 18 |

## Architecture

The ESX Network consists of a **Global Unity Chain** (L0) that serves as the primary settlement layer, a **Global Identity Chain** for decentralized identity, and **7 continental sub-chains** serving distinct geographic regions. All chains share a unified `ex`-prefixed address format with 18-decimal native tokens for full EVM/Frontier compatibility.