### PR TITLE
Add feat: register SS58 prefixes 59 (VU) and 60 (Vu) for VuNiti ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ss58-registry"
 authors = ["Parity Technologies <admin@parity.io>"]
-version = "1.51.0"
+version = "1.52.0"
 edition = "2021"
 description = "Registry of known SS58 address types"
 license = "Apache-2.0"

--- a/ss58-registry.json
+++ b/ss58-registry.json
@@ -542,6 +542,24 @@
       "website": "http://www.ysknfr.cn/"
     },
     {
+      "prefix": 59,
+      "network": "vuniti_global",
+      "displayName": "VuNiti Global",
+      "symbols": ["VU"],
+      "decimals": [12],
+      "standardAccount": "*25519",
+      "website": "https://vuniti.com"
+    },
+    {
+      "prefix": 60,
+      "network": "vuniti_china",
+      "displayName": "VuNiti China",
+      "symbols": ["Vu"],
+      "decimals": [12],
+      "standardAccount": "*25519",
+      "website": "https://vuniti.cn"
+    },
+    {
       "prefix": 63,
       "network": "hydradx",
       "displayName": "Hydration",


### PR DESCRIPTION
Title: Add SS58 prefixes 59 and 60 for VuNiti Ecosystem

Description:

Project: VuNiti (悠逸)
Prefix 59: Dedicated to VuNiti Global (Brand visual: 6VU...)
Prefix 60: Dedicated to VuNiti China (Brand visual: 6Vu...)
Website: https://vuniti.com/
Description: A humanistic social ecosystem using Substrate as the identity layer. We request these contiguous prefixes to distinguish between international and local regions while maintaining brand consistency.